### PR TITLE
Add a more space-efficient song looping method

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ midirenderer [OPTION...] <files> -f <soundfont>
   -d, --destination output      The folder to place the rendered files in
       --loop                    Render the audio looped to help make the loop
                                 more seamless at the cost of filesize
+      --loop-mode short|double  The mode to use when rendering the audio
+                                looped (implies --loop)
+                                  short: (default) render again from the
+                                start of the loop until all voices from the end
+                                have terminated (minimal filesize impact)
+                                  double: loop the whole song again (cleanest
+                                loop)
       --end-on-division 4       Align the end of the song to a note division
                                 up to a 64th note
 ```
@@ -81,3 +88,10 @@ The build process for your distribution should be straightforward, especially if
 The project supports packaging itself for distribution using `cmake --build . --target PACKAGE` on Windows. This generates a standalone distribution in your CMake working directory called `midirenderer-<version>-<target>.zip`. On Windows, MIDIRenderer's DLL dependency tree is automatically copied into the build folder. The packaging target uses CPack, so you may change the packaging parameters according to the [CPack documentation](https://cmake.org/cmake/help/latest/module/CPack.html). MIDIRenderer has not necessarily been configured for proper installer creation; your mileage may vary.
 
 The same CPack packager may be used with `make package`, but it is recommended you use `make install` or `checkinstall` instead.
+
+## Third-party software notices
+
+MIDIRenderer uses third-party software. License notices for this software is included in the `licenses` folder in this repository's root directory. Copies of these license notices are included in distributions of this software packaged using the above packaging method.
+
+MIDIRenderer contains a modified version of the following third-party software:
+- cxxopts 2.2.0

--- a/src/cxxopts.hpp
+++ b/src/cxxopts.hpp
@@ -1465,8 +1465,11 @@ namespace cxxopts
 
         if (*current == '\n')
         {
+		  stringAppend(result, startLine, current + 1);
+		  stringAppend(result, start, ' ');
           startLine = current + 1;
           lastSpace = startLine;
+		  size = 0;
         }
         else if (size > width)
         {

--- a/src/midirenderer.cpp
+++ b/src/midirenderer.cpp
@@ -30,8 +30,8 @@ int MAIN(int argc, argv_t** argv)
 		("d,destination", "The folder to place the rendered files in", cxxopts::value<std::string>(), "output")
 		("loop", "Render the audio looped to help make the loop more seamless at the cost of filesize")
 		("loop-mode", "The mode to use when rendering the audio looped (implies --loop)\n"
-			"\tshort: (default) after the end of the song, render again from the start of the loop until all voices from the end have terminated (minimal filesize impact)\n"
-			"\tdouble: loop the audio twice (cleanest loop)", cxxopts::value<std::string>(), "short|double")
+			"  short: (default) render again from the start of the loop until all voices from the end have terminated (minimal filesize impact)\n"
+			"  double: loop the whole song again (cleanest loop)", cxxopts::value<std::string>(), "short|double")
 		("end-on-division", "Align the end of the song to a note division up to a 64th note",
 			cxxopts::value<int>(), "4");
 	options.parse_positional({ "files" });

--- a/src/midivorbisrenderer.cpp
+++ b/src/midivorbisrenderer.cpp
@@ -16,21 +16,18 @@ namespace midirenderer
 	{
 		fluid_player_t* m_player;
 		fluid_synth_t* m_synth;
-		bool m_isLoopingInFile;
 		int m_loopTick;
 		int m_queuedSeek;
-		int m_queuedSeekLaunchTick;
 		bool m_hasHitLoopPoint;
 
-		PlayerCallbackData(fluid_player_t* player, fluid_synth_t* synth, bool isLoopingInFile) :
-			m_player(player), m_synth(synth), m_isLoopingInFile(isLoopingInFile),
+		PlayerCallbackData(fluid_player_t* player, fluid_synth_t* synth) : m_player(player), m_synth(synth),
 			m_loopTick(-1), m_queuedSeek(-1), m_hasHitLoopPoint(false) { }
 	};
 
-	MIDIVorbisRenderer::MIDIVorbisRenderer(bool isLoopingInFile, int endingBeatDivision) :
-		m_isLoopingInFile(isLoopingInFile), m_endingBeatDivision(endingBeatDivision),
+	MIDIVorbisRenderer::MIDIVorbisRenderer(LoopMode loopMode, int endingBeatDivision) :
+		m_loopMode(loopMode), m_endingBeatDivision(endingBeatDivision),
 		m_fluidSettings(nullptr, nullptr),
-		m_synth(nullptr, nullptr)
+		m_synth(nullptr, nullptr), m_framesSinceSynthClear(0)
 	{
 		m_fluidSettings = deleter_unique_ptr<fluid_settings_t>(new_fluid_settings(), delete_fluid_settings);
 
@@ -72,16 +69,12 @@ namespace midirenderer
 		rng.seed(time(NULL));
 		OggVorbisEncoder encoder = OggVorbisEncoder(static_cast<int>(rng()), 44100, 0.4);
 
-		PlayerCallbackData callbackData(nullptr, m_synth.get(), m_isLoopingInFile);
+		PlayerCallbackData callbackData(nullptr, m_synth.get());
 		uint64_t samplePosition = 0;
 		bool hasLoopPoint = false;
 		uint64_t loopPoint = 0;
 
 		renderSong(callbackData, sourcePath, encoder, hasLoopPoint, loopPoint, samplePosition);
-		if (m_isLoopingInFile)
-		{
-			renderSong(callbackData, sourcePath, encoder, hasLoopPoint, loopPoint, samplePosition);
-		}
 
 		fluid_synth_all_sounds_off(m_synth.get(), -1);
 
@@ -118,32 +111,10 @@ namespace midirenderer
 		callbackData.m_player = player.get();
 		fluid_player_set_playback_callback(player.get(), playerEventCallback, static_cast<void*>(&callbackData));
 
-#ifndef WINDOWS_UTF16_WORKAROUND
-		fluid_player_add(player.get(), fileName.c_str());
-#else
-		size_t filenameSize = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, fileName.c_str(), -1, NULL, 0);
-		auto filenameString = std::make_unique<wchar_t[]>(filenameSize);
-		MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, fileName.c_str(), -1, filenameString.get(), filenameSize);
-
-		std::shared_ptr<FILE> file(_wfopen(filenameString.get(), L"rb"), fclose);
-
-		if (file.get() == NULL)
-		{
-			throw std::invalid_argument("Failed to open MIDI file at " + fileName);
-		}
-
-		_fseeki64(file.get(), 0LL, SEEK_END);
-		__int64 fileLength = _ftelli64(file.get());
-		rewind(file.get());
-		auto fileContents = std::make_unique<char[]>(fileLength);
-
-		fread_s(fileContents.get(), fileLength, sizeof(char), fileLength, file.get());
-
-		fluid_player_add_mem(player.get(), fileContents.get(), fileLength);
-		file.reset();
-#endif
+		loadMIDIFile(fileName, player.get());
 
 		fluid_player_play(player.get());
+		clearSynthBuffer();
 
 		float leftBuffer[s_audioBufferSize];
 		float rightBuffer[s_audioBufferSize];
@@ -151,6 +122,7 @@ namespace midirenderer
 
 		int lastTempo = fluid_player_get_midi_tempo(player.get());
 		uint64_t lastTempoSample = samplePosition;
+		uint64_t loopStartSample = 0;
 
 		while (fluid_player_get_status(player.get()) == FLUID_PLAYER_PLAYING)
 		{
@@ -160,6 +132,9 @@ namespace midirenderer
 			{
 				hasLoopPoint = true;
 				loopPoint = samplePosition;
+				// The loop point actually happened one buffer ago so we need to move the loop point backward
+				loopPoint -= fluid_synth_get_internal_bufsize(m_synth.get());
+				loopStartSample = samplePosition;
 			}
 
 			int tempo = fluid_player_get_midi_tempo(player.get());
@@ -181,24 +156,173 @@ namespace midirenderer
 			double beatsElapsed = samplesSinceTempoChange / samplesPerAlignedBeat;
 			uint64_t lastAlignedBeat = static_cast<uint64_t>(beatsElapsed) + 1.0;
 			uint64_t lastSample = static_cast<uint64_t>(lastAlignedBeat * samplesPerAlignedBeat);
-			for (int j = samplePosition; j <= lastSample; j++)
+			for (int i = samplePosition; i < lastSample; i++)
 			{
 				readSampleFromSynth(leftBuffer, rightBuffer, bufferIndex, encoder);
 				samplePosition++;
 			}
 		}
 
+		// To ensure no non-runoff samples are written to the encoder as overlap samples,
+		// all buffered samples need to be written to the encoder before playing voice runoff
+		flushBuffersToEncoder(leftBuffer, rightBuffer, bufferIndex, encoder);
+
 		// Play the voice runoff of the end, which may or may not end up part of the loop
 
 		// samplePosition isn't incremented here because it's used to determine loop points
 		// and the runoff is not meant to delay the loop point at the end of the song.
 		encoder.startOverlapRegion();
+
+		size_t overlapSamples = 0;
 		while (fluid_synth_get_active_voice_count(m_synth.get()) > 0)
 		{
 			readSampleFromSynth(leftBuffer, rightBuffer, bufferIndex, encoder);
+			overlapSamples++;
 		}
 		flushBuffersToEncoder(leftBuffer, rightBuffer, bufferIndex, encoder);
+
 		encoder.endOverlapRegion();
+
+		// When looping in-file, the runoff period is used to transition to a partial second
+		// playthrough of the song, which is the same length of the runoff period. In theory,
+		// this means that the loop is made seamless since the sound from the end of the loop
+		// carry into the sound at the beginning of the loop.
+		if (m_loopMode != LoopMode::None)
+		{
+			deleter_unique_ptr<fluid_player_t> loopPlayer(new_fluid_player(m_synth.get()), delete_fluid_player);
+
+			callbackData.m_player = loopPlayer.get();
+			fluid_player_set_playback_callback(loopPlayer.get(), playerEventCallback, static_cast<void*>(&callbackData));
+
+			loadMIDIFile(fileName, loopPlayer.get());
+
+			switch (m_loopMode)
+			{
+			case LoopMode::Short:
+			{
+				fluid_player_play(loopPlayer.get());
+				clearSynthBuffer();
+
+				// Just jumping to the loop point seems to create an unavoidable pop when the rendered file's loop point is reached
+				// (the short loop mode end, not the song loop point) but synthesizing up to the song loop point and throwing
+				// the result away seems to loop just fine...
+				flushBuffersToEncoder(leftBuffer, rightBuffer, bufferIndex, encoder);
+
+				int synthBufferSize = fluid_synth_get_internal_bufsize(m_synth.get());
+				uint64_t samplesToLoopPoint = loopStartSample - synthBufferSize;
+
+				float throwawayBuffer = 0;
+				fluid_synth_write_float(m_synth.get(), samplesToLoopPoint, &throwawayBuffer, 0, 0, &throwawayBuffer, 0, 0);
+				m_framesSinceSynthClear = (m_framesSinceSynthClear + samplesToLoopPoint) % synthBufferSize;
+
+				fluid_synth_all_sounds_off(m_synth.get(), -1);
+				clearSynthBuffer();
+
+				for (int i = 0; i < overlapSamples; i++)
+				{
+					readSampleFromSynth(leftBuffer, rightBuffer, bufferIndex, encoder);
+				}
+
+				samplePosition += overlapSamples;
+				loopPoint += overlapSamples;
+
+				flushBuffersToEncoder(leftBuffer, rightBuffer, bufferIndex, encoder);
+
+				// Synthesizing a little bit extra helps prevent a small pop, click or other
+				// looping artifact caused by Vorbis' lossy encoding. See the Vorbis documentation
+				// for more information: https://xiph.org/vorbis/doc/vorbisfile/crosslap.html
+				// The main idea: synthesizing an extra 64 samples will help Vorbis decoders
+				// avoid a pop when looping. This only helps for applications that use Vorbis
+				// lapping when playing Vorbis files, which RPG Maker MV (through the Chromium
+				// implementation of the Web Audio API) doesn't seem to use.
+
+				// Additionally, this might also give the compression some more information to place
+				// the very last sample in the right spot, which might prevent a very, very tiny click
+				// from the last sample not quite fitting
+
+				encoder.startOverlapRegion();
+
+				for (int i = 0; i < 64; i++)
+				{
+					readSampleFromSynth(leftBuffer, rightBuffer, bufferIndex, encoder);
+				}
+				flushBuffersToEncoder(leftBuffer, rightBuffer, bufferIndex, encoder);
+
+				encoder.endOverlapRegion();
+
+				fluid_player_stop(loopPlayer.get());
+				break;
+			}
+			case LoopMode::Double:
+			{
+				callbackData.m_queuedSeek = callbackData.m_loopTick;
+				loopPoint = samplePosition;
+				fluid_player_play(loopPlayer.get());
+				while (fluid_player_get_status(loopPlayer.get()) == FLUID_PLAYER_PLAYING)
+				{
+					readSampleFromSynth(leftBuffer, rightBuffer, bufferIndex, encoder);
+
+					int tempo = fluid_player_get_midi_tempo(loopPlayer.get());
+					if (tempo != lastTempo)
+					{
+						lastTempo = tempo;
+						lastTempoSample = samplePosition;
+					}
+					samplePosition++;
+				}
+
+				fluid_player_join(loopPlayer.get());
+
+				if (m_endingBeatDivision != -1)
+				{
+					uint64_t samplesSinceTempoChange = samplePosition - lastTempoSample;
+					double alignmentTempo = 4.0 / m_endingBeatDivision * (lastTempo / 1000000.0);
+					double samplesPerAlignedBeat = 44100.0 * (alignmentTempo);
+					double beatsElapsed = samplesSinceTempoChange / samplesPerAlignedBeat;
+					uint64_t lastAlignedBeat = static_cast<uint64_t>(beatsElapsed) + 1.0;
+					uint64_t lastSample = static_cast<uint64_t>(lastAlignedBeat * samplesPerAlignedBeat);
+					for (int j = samplePosition; j <= lastSample; j++)
+					{
+						readSampleFromSynth(leftBuffer, rightBuffer, bufferIndex, encoder);
+						samplePosition++;
+					}
+				}
+
+				flushBuffersToEncoder(leftBuffer, rightBuffer, bufferIndex, encoder);
+				break;
+			}
+			default:
+				throw std::runtime_error("Attempted to loop with invalid loop mode " + std::to_string(static_cast<int>(m_loopMode)));
+			}
+		}
+	}
+
+	void MIDIVorbisRenderer::loadMIDIFile(std::string& fileName, fluid_player_t* player)
+	{
+#ifndef WINDOWS_UTF16_WORKAROUND
+		fluid_player_add(player, fileName.c_str());
+#else
+		size_t filenameSize = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, fileName.c_str(), -1, NULL, 0);
+		auto filenameString = std::make_unique<wchar_t[]>(filenameSize);
+		MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, fileName.c_str(), -1, filenameString.get(), filenameSize);
+
+		std::shared_ptr<FILE> file(_wfopen(filenameString.get(), L"rb"), fclose);
+
+		if (file.get() == NULL)
+		{
+			throw std::invalid_argument("Failed to open MIDI file at " + fileName);
+		}
+
+		_fseeki64(file.get(), 0LL, SEEK_END);
+		__int64 fileLength = _ftelli64(file.get());
+		rewind(file.get());
+		auto fileContents = std::make_unique<char[]>(fileLength);
+
+		fread_s(fileContents.get(), fileLength, sizeof(char), fileLength, file.get());
+
+		fluid_player_add_mem(player, fileContents.get(), fileLength);
+		file.reset();
+#endif
 	}
 
 	void MIDIVorbisRenderer::readSampleFromSynth(float* leftBuffer, float* rightBuffer, size_t& bufferIndex, OggVorbisEncoder& encoder)
@@ -207,12 +331,22 @@ namespace midirenderer
 		{
 			throw std::runtime_error("Synth encountered an error");
 		}
+
+		m_framesSinceSynthClear = (m_framesSinceSynthClear + 1) % fluid_synth_get_internal_bufsize(m_synth.get());
+
 		bufferIndex++;
 		if (bufferIndex >= s_audioBufferSize)
 		{
 			bufferIndex -= s_audioBufferSize;
 			encoder.writeBuffers(leftBuffer, rightBuffer, s_audioBufferSize);
 		}
+	}
+
+	void MIDIVorbisRenderer::clearSynthBuffer()
+	{
+		int fluidBufferSize = fluid_synth_get_internal_bufsize(m_synth.get());
+		auto buffer = std::make_unique<float[]>(fluidBufferSize * 2);
+		fluid_synth_write_float(m_synth.get(), fluidBufferSize - m_framesSinceSynthClear, buffer.get(), 0, 1, buffer.get(), fluidBufferSize, 1);
 	}
 
 	void MIDIVorbisRenderer::flushBuffersToEncoder(float* leftBuffer, float* rightBuffer, size_t& bufferLength, OggVorbisEncoder& encoder)
@@ -228,10 +362,7 @@ namespace midirenderer
 	{
 		PlayerCallbackData* callbackData = static_cast<PlayerCallbackData*>(data);
 
-		int currentTick = fluid_player_get_current_tick(callbackData->m_player);
-
-		if (callbackData->m_queuedSeek != -1 &&
-			currentTick < callbackData->m_queuedSeekLaunchTick)
+		if (callbackData->m_queuedSeek != -1)
 		{
 			fluid_player_seek(callbackData->m_player, callbackData->m_queuedSeek);
 			callbackData->m_queuedSeek = -1;
@@ -243,27 +374,10 @@ namespace midirenderer
 
 		if (eventCode == 0xb0 && eventControl == 111)
 		{
-			if (callbackData->m_isLoopingInFile)
-			{
-				callbackData->m_loopTick = currentTick;
-			}
-			else
-			{
-				callbackData->m_hasHitLoopPoint = true;
-			}
+			callbackData->m_hasHitLoopPoint = true;
+			callbackData->m_loopTick = fluid_player_get_current_tick(callbackData->m_player);
 		}
 
-		if (callbackData->m_queuedSeek == -1 &&
-			callbackData->m_loopTick >= 0 &&
-			currentTick == fluid_player_get_total_ticks(callbackData->m_player))
-		{
-			if (callbackData->m_isLoopingInFile)
-			{
-				callbackData->m_queuedSeek = callbackData->m_loopTick;
-				callbackData->m_queuedSeekLaunchTick = currentTick;
-				callbackData->m_hasHitLoopPoint = true;
-			}
-		}
 		return fluid_synth_handle_midi_event(callbackData->m_synth, event);
 	}
 }

--- a/src/midivorbisrenderer.cpp
+++ b/src/midivorbisrenderer.cpp
@@ -197,11 +197,7 @@ namespace midirenderer
 		{
 			readSampleFromSynth(leftBuffer, rightBuffer, bufferIndex, encoder);
 		}
-
-		if (bufferIndex != 0)
-		{
-			encoder.writeBuffers(leftBuffer, rightBuffer, bufferIndex);
-		}
+		flushBuffersToEncoder(leftBuffer, rightBuffer, bufferIndex, encoder);
 		encoder.endOverlapRegion();
 	}
 
@@ -216,6 +212,15 @@ namespace midirenderer
 		{
 			bufferIndex -= s_audioBufferSize;
 			encoder.writeBuffers(leftBuffer, rightBuffer, s_audioBufferSize);
+		}
+	}
+
+	void MIDIVorbisRenderer::flushBuffersToEncoder(float* leftBuffer, float* rightBuffer, size_t& bufferLength, OggVorbisEncoder& encoder)
+	{
+		if (bufferLength > 0)
+		{
+			encoder.writeBuffers(leftBuffer, rightBuffer, bufferLength);
+			bufferLength = 0;
 		}
 	}
 

--- a/src/midivorbisrenderer.h
+++ b/src/midivorbisrenderer.h
@@ -37,6 +37,14 @@ namespace midirenderer
 
 		void renderSong(PlayerCallbackData& callbackData, std::string fileName, OggVorbisEncoder& encoder, bool& hasLoopPoint, uint64_t& loopPoint, uint64_t& samplePosition);
 
+		void renderShortLoop(deleter_unique_ptr<fluid_player_t>& player, float* leftBuffer, float* rightBuffer, size_t& bufferIndex, OggVorbisEncoder& encoder,
+			uint64_t loopStartSample, size_t overlapSamples, uint64_t& samplePosition, uint64_t& loopPoint);
+
+		void renderDoubleLoop(PlayerCallbackData& callbackData, deleter_unique_ptr<fluid_player_t>& player, float* leftBuffer, float* rightBuffer, size_t& bufferIndex, OggVorbisEncoder& encoder,
+			uint64_t& loopPoint, uint64_t& samplePosition, int& lastTempo, uint64_t& lastTempoSample);
+
+		void renderToBeatDivision(uint64_t& samplePosition, uint64_t lastTempoSample, int lastTempo, float* leftBuffer, float* rightBuffer, size_t& bufferIndex, OggVorbisEncoder& encoder);
+
 		void readSampleFromSynth(float* leftBuffer, float* rightBuffer, size_t& bufferIndex, OggVorbisEncoder& encoder);
 		void clearSynthBuffer();
 		void flushBuffersToEncoder(float* leftBuffer, float* rightBuffer, size_t& bufferLength, OggVorbisEncoder& encoder);

--- a/src/midivorbisrenderer.h
+++ b/src/midivorbisrenderer.h
@@ -24,6 +24,7 @@ namespace midirenderer
 	private:
 		void renderSong(PlayerCallbackData& callbackData, std::string fileName, OggVorbisEncoder& encoder, bool& hasLoopPoint, uint64_t& loopPoint, uint64_t& samplePosition);
 		void readSampleFromSynth(float* leftBuffer, float* rightBuffer, size_t& bufferIndex, OggVorbisEncoder& encoder);
+		void flushBuffersToEncoder(float* leftBuffer, float* rightBuffer, size_t& bufferLength, OggVorbisEncoder& encoder);
 		static int playerEventCallback(void* data, fluid_midi_event_t* event);
 
 		template<typename T>

--- a/src/midivorbisrenderer.h
+++ b/src/midivorbisrenderer.h
@@ -14,7 +14,14 @@ namespace midirenderer
 	class MIDIVorbisRenderer
 	{
 	public:
-		MIDIVorbisRenderer(bool isLoopingInFile = false, int endingBeatDivision = -1);
+		enum class LoopMode
+		{
+			None,
+			Double,
+			Short
+		};
+
+		MIDIVorbisRenderer(LoopMode loopMode = LoopMode::None, int endingBeatDivision = -1);
 
 		void loadSoundfont(std::string soundfontPath);
 
@@ -22,23 +29,30 @@ namespace midirenderer
 
 		bool getHasSoundfont();
 	private:
-		void renderSong(PlayerCallbackData& callbackData, std::string fileName, OggVorbisEncoder& encoder, bool& hasLoopPoint, uint64_t& loopPoint, uint64_t& samplePosition);
-		void readSampleFromSynth(float* leftBuffer, float* rightBuffer, size_t& bufferIndex, OggVorbisEncoder& encoder);
-		void flushBuffersToEncoder(float* leftBuffer, float* rightBuffer, size_t& bufferLength, OggVorbisEncoder& encoder);
-		static int playerEventCallback(void* data, fluid_midi_event_t* event);
-
 		template<typename T>
 		using deleter_t = void(*)(T*);
 
 		template<typename T>
 		using deleter_unique_ptr = std::unique_ptr<T, deleter_t<T>>;
 
-		bool m_isLoopingInFile;
+		void renderSong(PlayerCallbackData& callbackData, std::string fileName, OggVorbisEncoder& encoder, bool& hasLoopPoint, uint64_t& loopPoint, uint64_t& samplePosition);
+
+		void readSampleFromSynth(float* leftBuffer, float* rightBuffer, size_t& bufferIndex, OggVorbisEncoder& encoder);
+		void clearSynthBuffer();
+		void flushBuffersToEncoder(float* leftBuffer, float* rightBuffer, size_t& bufferLength, OggVorbisEncoder& encoder);
+
+		static void loadMIDIFile(std::string &fileName, fluid_player_t* loopPlayer);
+		static int playerEventCallback(void* data, fluid_midi_event_t* event);
+
+		LoopMode m_loopMode;
 		int m_endingBeatDivision;
 
 		deleter_unique_ptr<fluid_settings_t> m_fluidSettings;
 		deleter_unique_ptr<fluid_synth_t> m_synth;
 
+		size_t m_framesSinceSynthClear;
+
 		constexpr static size_t s_audioBufferSize = 1024;
+		constexpr static size_t s_loopClickBufferSize = 128;
 	};
 }

--- a/src/oggvorbisencoder.h
+++ b/src/oggvorbisencoder.h
@@ -28,6 +28,7 @@ public:
 private:
 	static void executePageCallback(const PageCallbackFunc& pageCallback, const ogg_page& page);
 	void encodeBuffers(const float* leftBuffer, const float* rightBuffer, size_t frameCount);
+	void flushBufferToStream();
 
 	void throwIfComplete();
 
@@ -43,6 +44,4 @@ private:
 	std::array<std::vector<float>, 2> m_overlapBuffers;
 	bool m_isWritingOverlapRegion;
 	size_t m_overlapOffset;
-
-	constexpr static size_t s_writeChunkSize = 1024;
 };


### PR DESCRIPTION
The current in-file looping method used to avoid an audible loop point caused by instruments cutting out at the seam wastes a significant amount of space - if a song loops from the beginning, the total length is doubled. This PR provides a more space-efficient method to loop songs without the obvious loop point.  This method only renders the second looped playback of the song until the instrument voices that are still playing at the end of the song have finished and then moves the end of the loop to the end of the decay time and moves the start of the loop by the same amount. The result is that the sound file internally is set to loop once all sounds from the end of the song have terminated, which is the earliest point at which the first and second plays of the song should be identical (barring instruments with a long decay that would be audible long after the starting loop point).

This feature adds a new command-line option, `--loop-mode`. Its help string is as follows:
```
      --loop-mode short|double  The mode to use when rendering the audio
                                looped (implies --loop)
                                  short: (default) render again from the
                                start of the loop until all voices from the end
                                have terminated (minimal filesize impact)
                                  double: loop the whole song again (cleanest
                                loop)
```

As the help string states, it implies the `--loop` option. The `--loop` option is kept to keep backward compatibility and the original loop method (now called "double") is kept in case an edge case causes it to provide a superior loop.

This PR also contains a few minor improvements to how FluidSynth is used by manually synthesizing away samples that are blank or that contain inappropriate data due to FluidSynth synthesizing in 64-sample batches. This was important for tightening up the timing to prevent an audible pop at the loop point in the file (which is now unlikely to be aligned to a beat).