### PR TITLE
Release v1.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(midirenderer VERSION 1.0.0)
+project(midirenderer VERSION 1.1.0)
 set(CMAKE_CXX_STANDARD 17)
 
 set(MSVC_USE_STATIC_RUNTIME_LIBRARY TRUE CACHE BOOL "Whether to use the static MSVC runtime or the runtime DLLs")


### PR DESCRIPTION
Changelog:
- Added a new method for rendering the loop in-file that takes significantly less space
- Added a new command-line option, --loop-mode short|double, that determines the looping mode. When this option is not provided with the --loop option, "short" is the default.
- Fixed a very brief period of silence at the beginning of the rendered file
- Fixed in-file looping playing a very short amount of time later than it should