### PR TITLE
Fix a typo that caused --end-on-beat to be handled incorrectly

### DIFF
--- a/src/midivorbisrenderer.cpp
+++ b/src/midivorbisrenderer.cpp
@@ -285,7 +285,7 @@ namespace midirenderer
 
 	void MIDIVorbisRenderer::renderToBeatDivision(uint64_t& samplePosition, uint64_t lastTempoSample, int lastTempo, float* leftBuffer, float* rightBuffer, size_t& bufferIndex, OggVorbisEncoder& encoder)
 	{
-		if (m_endingBeatDivision != -1) { return; }
+		if (m_endingBeatDivision == -1) { return; }
 
 		uint64_t samplesSinceTempoChange = samplePosition - lastTempoSample;
 		double alignmentTempo = 4.0 / m_endingBeatDivision * (lastTempo / 1000000.0);


### PR DESCRIPTION
Closes #3

The mechanism for ending the song on beat was incorrectly only triggering if the value were unset (-1), which made the formula cast a negative double to a very large unsigned number, making the mechanism render a very large positive number of samples (millions of years!).