### PR TITLE
Change the renderer to always output loop metadata when using loop options

### DIFF
--- a/src/midivorbisrenderer.h
+++ b/src/midivorbisrenderer.h
@@ -32,7 +32,7 @@ namespace midirenderer
 
 		bool getHasSoundfont();
 	private:
-		void renderSong(PlayerCallbackData& callbackData, std::string fileName, OggVorbisEncoder& encoder, bool& hasLoopPoint, uint64_t& loopPoint, uint64_t& samplePosition);
+		void renderSong(PlayerCallbackData& callbackData, std::string fileName, OggVorbisEncoder& encoder, uint64_t& loopStart, uint64_t& songLength);
 
 		void renderShortLoop(SongRenderContainer& songRenderer, float* leftBuffer, float* rightBuffer, size_t& bufferIndex, OggVorbisEncoder& encoder,
 			uint64_t loopStartSample, size_t overlapSamples, uint64_t& samplePosition, uint64_t& loopPoint);


### PR DESCRIPTION
The previous behavior was to render with extra loop samples depending on the user's command-line looping options but to add loop metadata to the output file when the input file has an RPG Maker-style MIDI loop point. Now, the loop metadata is also added based on the loop options used, bringing both behaviors together.
Fixes #12