### PR TITLE
Release v1.1.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ list(APPEND MIDIRENDERER_SRC
 	src/platformchar.h
 	src/platformsupport.h
 	src/platformargswrapper.h
+	src/deleteruniqueptr.h
 	src/pathresolution.h
 	src/oggvorbisencoder.h
 	src/midivorbisrenderer.h

--- a/src/deleteruniqueptr.h
+++ b/src/deleteruniqueptr.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <memory>
 
 template<typename T>
 using deleter_t = void(*)(T*);

--- a/src/midivorbisrenderer.h
+++ b/src/midivorbisrenderer.h
@@ -32,7 +32,7 @@ namespace midirenderer
 
 		bool getHasSoundfont();
 	private:
-		void renderSong(PlayerCallbackData& callbackData, std::string fileName, OggVorbisEncoder& encoder, bool& hasLoopPoint, uint64_t& loopPoint, uint64_t& samplePosition);
+		void renderSong(PlayerCallbackData& callbackData, std::string fileName, OggVorbisEncoder& encoder, uint64_t& loopStart, uint64_t& songLength);
 
 		void renderShortLoop(SongRenderContainer& songRenderer, float* leftBuffer, float* rightBuffer, size_t& bufferIndex, OggVorbisEncoder& encoder,
 			uint64_t loopStartSample, size_t overlapSamples, uint64_t& samplePosition, uint64_t& loopPoint);

--- a/src/songrendercontainer.cpp
+++ b/src/songrendercontainer.cpp
@@ -108,7 +108,7 @@ namespace midirenderer
 	void SongRenderContainer::loadMIDIFile()
 	{
 #ifndef WINDOWS_UTF16_WORKAROUND
-		fluid_player_add(m_player.get(), fileName.c_str());
+		fluid_player_add(m_player.get(), m_fileName.c_str());
 #else
 		size_t filenameSize = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, m_fileName.c_str(), -1, NULL, 0);
 		auto filenameString = std::make_unique<wchar_t[]>(filenameSize);


### PR DESCRIPTION
Changelog:
- Fixed batch rendering causing a small amount of sound from a song sometimes becoming part of the next song in the batch (#8)
- Fixed batch rendering sometimes hanging due to issues with rendering songs in sequence with the same synth and player (#9)
- Fixed songs without loop points containing looped sound but no loop metadata when rendered with loop-related command-line options (#12)